### PR TITLE
fixed the 1st page crawling issue; was crawling only 'next' pages and…

### DIFF
--- a/reddit/spiders/pic.py
+++ b/reddit/spiders/pic.py
@@ -10,10 +10,10 @@ class PicSpider(CrawlSpider):
     start_urls = ['http://www.reddit.com/r/pics/']
 
     rules = [
-    	Rule(LinkExtractor(
-    		allow=['/r/pics/\?count=\d*&after=\w*']),
-    		callback='parse_item',
-    		follow=True)
+        Rule(LinkExtractor(
+            allow=['/r/pics/\?count=\d*&after=\w*']),
+            callback='parse_start_url',
+            follow=True)
     ]
 
     # rules = [
@@ -22,19 +22,19 @@ class PicSpider(CrawlSpider):
     #     # It's also important to NOT override the parse method
     #     # the parse method is used by the CrawlSpider continuously extract links
     #     Rule(LinkExtractor(
-    #     	allow=['/r/pics/\?count=\d*&after=\w*']),
-    #     	callback='parse_item',
-    #     	follow=True),
+    #       allow=['/r/pics/\?count=\d*&after=\w*']),
+    #       callback='parse_item',
+    #       follow=True),
     # ]
 
-    def parse_item(self, response):
+    def parse_start_url(self, response):
         
         selector_list = response.css('div.thing')
 
         for selector in selector_list:
-        	item = PicItem()
-        	item['image_urls'] = selector.xpath('a/@href').extract()
-        	item['title'] = selector.xpath('div/p/a/text()').extract()
-        	item['url'] = selector.xpath('a/@href').extract()
+            item = PicItem()
+            item['image_urls'] = selector.xpath('a/@href').extract()
+            item['title'] = selector.xpath('div/p/a/text()').extract()
+            item['url'] = selector.xpath('a/@href').extract()
 
-        	yield item
+            yield item


### PR DESCRIPTION
… ignoring starting one

Overriding `parse_start_url` method makes the spider crawling the starting page as well.
